### PR TITLE
Add simple progress tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,14 @@ Although this is a personal challenge repository, I'm always open to suggestions
 Let's embark on this Python journey together and become better programmers one challenge at a time!
 
 Happy coding! 🐍
+
+## Progress Tracker
+
+Use `progress_tracker.py` to record which days you've completed. Run the script with a day number to mark it as finished:
+
+```bash
+python progress_tracker.py 1
+```
+
+Running the script without arguments shows your overall progress.
+

--- a/progress.json
+++ b/progress.json
@@ -1,0 +1,1 @@
+{"completed_days": []}

--- a/progress_tracker.py
+++ b/progress_tracker.py
@@ -1,0 +1,48 @@
+import json
+import os
+import sys
+
+PROGRESS_FILE = 'progress.json'
+TOTAL_DAYS = 100
+
+def load_progress():
+    if os.path.exists(PROGRESS_FILE):
+        with open(PROGRESS_FILE, 'r') as f:
+            try:
+                data = json.load(f)
+                return set(data.get('completed_days', []))
+            except json.JSONDecodeError:
+                return set()
+    return set()
+
+def save_progress(days):
+    with open(PROGRESS_FILE, 'w') as f:
+        json.dump({'completed_days': sorted(days)}, f, indent=2)
+
+def print_progress(days):
+    completed = len(days)
+    percent = completed / TOTAL_DAYS * 100
+    print(f"Completed {completed}/{TOTAL_DAYS} days ({percent:.1f}%):")
+    progress_bar = '[' + '#' * int(percent // 2) + ' ' * (50 - int(percent // 2)) + ']'
+    print(progress_bar)
+
+def main():
+    days = load_progress()
+
+    if len(sys.argv) > 1:
+        try:
+            day = int(sys.argv[1])
+            if day < 1 or day > TOTAL_DAYS:
+                print(f"Day must be between 1 and {TOTAL_DAYS}.")
+                return
+            days.add(day)
+            save_progress(days)
+            print(f"Marked day {day} as completed.")
+        except ValueError:
+            print("Please provide a valid day number.")
+            return
+
+    print_progress(days)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `progress_tracker.py` to log completed days
- store finished days in `progress.json`
- document progress tracker usage in README

## Testing
- `python3 progress_tracker.py`


------
https://chatgpt.com/codex/tasks/task_e_683fc86f56fc832b97c5bfbc34ae9db8